### PR TITLE
Fix light-weighted (LW) dists for cube

### DIFF
--- a/popkinmocks/components.py
+++ b/popkinmocks/components.py
@@ -1264,14 +1264,10 @@ class stream(component):
         p_zt = p_z_t*p_t
         p_tz = p_zt.T
         if light_weighted:
-            light_weights = self.cube.ssps.light_weights
-            normalisation = np.sum(p_tz*light_weights)
-            p_tz = p_tz*light_weights/normalisation
-            if density:
-                dt = self.cube.ssps.delta_t
-                dz = self.cube.ssps.delta_z
-                dtdz = dt[:,np.newaxis] * dz[np.newaxis,:]
-                p_tz /= dtdz
+            ssps = self.cube.ssps
+            P_tz_mass_wtd = self.get_p_tz(density=False)
+            normalisation = np.sum(P_tz_mass_wtd*ssps.light_weights)
+            p_tz = p_tz*ssps.light_weights/normalisation
         return p_tz
 
     def get_p_z(self, density=True, light_weighted=False):

--- a/popkinmocks/ifu_cube.py
+++ b/popkinmocks/ifu_cube.py
@@ -122,8 +122,9 @@ class IFUCube(object):
     def get_p(self,
               which_dist,
               collapse_cmps=False,
-              *args,
-              **kwargs):
+              density=True,
+              light_weighted=False,
+              v_edg=None):
         """Evaluate densities of the galaxy
 
         5D densities over: stellar age (t), 2D position (x), velocity (v), and
@@ -175,16 +176,134 @@ class IFUCube(object):
                               'tvxz',
                               'v_x',
                               'v']
+        if light_weighted is False:
+            count = 0
+            for i, (cmp, w) in enumerate(zip(self.component_list,self.weights)):
+                p_func = getattr(cmp, 'get_p_'+which_dist)
+                if 'v' in which_dist:
+                    pi = w * p_func(v_edg=v_edg,
+                                    density=density,
+                                    light_weighted=False)
+                else:
+                    pi = w * p_func(density=density, light_weighted=False)
+                if count == 0:
+                    p = np.zeros((self.n_cmps,) + pi.shape)
+                p[i] = pi
+                count += 1
+        else:
+            p = self.get_light_weighted_distributions(
+                which_dist,
+                density=density,
+                light_weighted=light_weighted,
+                v_edg=v_edg)
+        if collapse_cmps:
+            p = np.sum(p, 0)
+        return p
+
+    def get_light_weighted_distributions(self,
+                                         which_dist,
+                                         density=True,
+                                         light_weighted=False,
+                                         v_edg=None):
+        dt = self.ssps.delta_t
+        dz = self.ssps.delta_z
+        if v_edg is not None:
+            dv = v_edg[1:] - v_edg[:-1]
+        dx2 = self.dx*self.dy
+        na = np.newaxis
         count = 0
-        for i, (cmp, w) in enumerate(zip(self.component_list, self.weights)):
-            p_func = getattr(cmp, 'get_p_'+which_dist)
-            pi = w * p_func(*args, **kwargs)
-            if count==0:
+        # evaluate mass-weighted probabilties over all (t,x,z) or (t,v,x,z) if
+        # v is in the target distribution
+        for i, (cmp, w) in enumerate(zip(self.component_list,self.weights)):
+            if 'v' in which_dist:
+                pi = w * cmp.get_p_tvxz(v_edg=v_edg,
+                                        density=False,
+                                        light_weighted=False)
+            else:
+                pi = w * cmp.get_p_txz(density=False, light_weighted=False)
+            if count == 0:
                 p = np.zeros((self.n_cmps,) + pi.shape)
             p[i] = pi
             count += 1
-        if collapse_cmps:
-            p = np.sum(p, 0)
+        # apply light-weighting
+        if 'v' in which_dist:
+            p *= self.ssps.light_weights[na,:,na,na,na,:]
+        else:
+            p *= self.ssps.light_weights[na,:,na,na,:]
+        p /= np.sum(p)
+        # at this point p = light-weighted P(i,t,v,x,z) / P(i,t,x,z) ...
+        # ... if v is / isn't in `which_dist` (and i indexes over components)
+        # now evaluate the desired marginal/conditional
+        if which_dist=='t':
+            p = np.sum(p, (2,3,4))
+            if density:
+                p /= dt[na,:]
+        elif which_dist=='x_t':
+            p_tx = np.sum(p, 4)
+            p_xt = np.moveaxis(p_tx, 1, -1)
+            p_t = np.sum(p, (0,2,3,4))      # this must be mrg. over i
+            p = p_xt/p_t[na,na,na,:]
+            if density:
+                p /= dx2
+        elif which_dist=='tx':
+            p = np.sum(p, 4)
+            if density:
+                p /= dx2*dt[na,:,na,na]
+        elif which_dist=='z_tx':
+            p_tx = np.sum(p, (0,4))
+            p_ztx = np.moveaxis(p, -1, 1)
+            p = p_ztx/p_tx[na,na,:,:,:]
+            if density:
+                p /= dz[na,:,na,na,na]
+        elif which_dist=='txz':
+            pass
+            if density:
+                dvol = dt[:,na,na,na]*dx2*dz[na,na,na,:]
+                p /= dvol
+        elif which_dist=='x':
+            p = np.sum(p, (1,4))
+            if density:
+                p /= dx2
+        elif which_dist=='z':
+            p = np.sum(p, (1,2,3))
+            if density:
+                p /= dz
+        elif which_dist=='tz_x':
+            p_tzx = np.moveaxis(p, -1, 2)
+            p_x = np.sum(p, (0,1,4))
+            p = p_tzx/p_x
+            if density:
+                dvol = dt[na,:,na,na,na] * dz[na,na,:,na,na]
+                p /= dvol
+        elif which_dist=='tz':
+            p = np.sum(p, (2,3))
+            if density:
+                dvol = dt[na,:,na]*dz[na,na,:]
+                p /= dvol
+        elif which_dist=='v_tx':
+            p_tvx = np.sum(p, -1)
+            p_vtx = np.moveaxis(p_tvx, 2, 1)
+            p_tx = np.sum(p, (0,2,-1))
+            p = p_vtx/p_tx[na,na,:,:,:]
+            if density:
+                p /= dv[na,:,na,na,na]
+        elif which_dist=='tvxz':
+            pass
+            if density:
+                dvol = dt[:,na,na,na,na]*dv[na,:,na,na,na]*dx2*dz[na,na,na,na,:]
+                p = p/dvol
+        elif which_dist=='v_x':
+            p_vx = np.sum(p, (1,5))
+            p_x = np.sum(p, (0,1,2,5))
+            p = p_vx/p_x[na,na,:,:]
+            if density:
+                p /= dv[na,:,na,na]
+        elif which_dist=='v':
+            p = np.sum(p, (1,3,4,5))
+            if density:
+                p /= dv[na,:]
+        else:
+            raise ValueErrror('Unknown value of which_dist')
         return p
 
     def get_E_v_x(self):

--- a/popkinmocks/stream.py
+++ b/popkinmocks/stream.py
@@ -1,0 +1,404 @@
+
+class stream(component):
+    """A stream with spatially varying kinematics but uniform enrichment.
+
+    The (mass-weighted) joint density of this component can be factorised as
+    p(t,x,v,z) = p(t) p(x) p(v|x) p(z|t)
+    where the factors are given by:
+    - p(t) : a beta distribution (see `set_p_t`),
+    - p(x) : a curved line with constant thickness (see `set_p_x`),
+    - p(v|x) : Guassian with mean varying along stream and constant sigma (see
+    set_p_v_x`),
+    - p(z|t) : single chemical evolution track i.. `t_dep` (see `set_p_z_t`).
+
+    Args:
+        cube: a pkm.mock_cube.mockCube.
+        center (x0,y0): co-ordinates of the component center.
+        rotation: angle (degrees) between x-axes of component and cube.
+        nsmp:
+
+    """
+    def __init__(self,
+                 cube=None,
+                 center=(0,0),
+                 rotation=0.):
+        super(stream, self).__init__(
+            cube=cube,
+            center=center,
+            rotation=rotation)
+
+    def set_p_x(self,
+                theta_lims=[0., np.pi/2.],
+                mu_r_lims=[0.7, 0.1],
+                sig=0.03,
+                nsmp=75):
+        """Define the stream track p(x)
+
+        Defined in polar co-ordinates (theta,r). Stream extends between angles
+        `theta_lims` between radii in `mu_r_lims`. Density is constant along
+        with varying theta. The track has a constant width on the sky, `sig`.
+
+        Args:
+            theta_lims: (start, end) values of stream angle in radians.
+            mu_r_lims: (start, end) values of stream distance from center.
+            sig (float): stream thickness.
+            nsmp (int): number of points to sample the angle theta.
+
+        Returns:
+            type: Description of returned object.
+
+        """
+        self.theta_lims = theta_lims
+        cube = self.cube
+        theta0, theta1 = theta_lims
+        self.nsmp = nsmp
+        theta_smp = np.linspace(theta0, theta1, self.nsmp)
+        mu_r0, mu_r1 = mu_r_lims
+        tmp = (theta_smp - theta0)/(theta1 - theta0)
+        mu_r_smp =  mu_r0 + (mu_r1 - mu_r0) * tmp
+        mu_x_smp = mu_r_smp * np.cos(theta_smp)
+        nrm_x = stats.norm(mu_x_smp, sig)
+        pdf_x = nrm_x.cdf(self.xxp[:,:,np.newaxis] + cube.dx/2.)
+        pdf_x -= nrm_x.cdf(self.xxp[:,:,np.newaxis] - cube.dx/2.)
+        mu_y_smp = mu_r_smp * np.sin(theta_smp)
+        nrm_y = stats.norm(mu_y_smp, sig)
+        pdf_y = nrm_y.cdf(self.yyp[:,:,np.newaxis] + cube.dy/2.)
+        pdf_y -= nrm_y.cdf(self.yyp[:,:,np.newaxis] - cube.dy/2.)
+        pdf = pdf_x * pdf_y
+        pdf = np.sum(pdf, -1)
+        pdf /= np.sum(pdf*cube.dx*cube.dy)
+        self.p_x_pars = dict(theta_lims=theta_lims,
+                             mu_r_lims=mu_r_lims,
+                             sig=sig,
+                             nsmp=nsmp)
+        self.p_x = pdf
+
+    def get_p_x(self, density=True, light_weighted=False):
+        """Get p(x)
+
+        Args:
+            density (bool): whether to return probabilty density (True) or the
+            volume-element weighted probabilty (False)
+            light_weighted (bool): whether to return light-weighted (True) or
+            mass-weighted (False) quantity
+
+        Returns:
+            array
+
+        """
+        # since x is indpt of (t,z), light- and mass- weight densities are equal
+        p_x = self.p_x.copy()
+        if density is False:
+            p_x *= (self.cube.dx * self.cube.dy)
+        return p_x
+
+    def get_p_x_t(self, density=True, light_weighted=False):
+        """Get p(x|t)
+
+        Args:
+            density (bool): whether to return probabilty density (True) or the
+            volume-element weighted probabilty (False)
+            light_weighted (bool): whether to return light-weighted (True) or
+            mass-weighted (False) quantity
+
+        Returns:
+            array
+
+        """
+        p_x = self.get_p_x(density=density, light_weighted=light_weighted)
+        # since x is indpt of t, p(x|t)=p(x)
+        nt = self.cube.ssps.par_dims[1]
+        p_x_t = np.broadcast_to(p_x[:,:,np.newaxis], p_x.shape+(nt,))
+        return p_x_t
+
+    def get_p_tx(self, density=True, light_weighted=False):
+        """Get p(t,x)
+
+        Args:
+            density (bool): whether to return probabilty density (True) or the
+            volume-element weighted probabilty (False)
+            light_weighted (bool): whether to return light-weighted (True) or
+            mass-weighted (False) quantity
+
+        Returns:
+            array
+
+        """
+        p_x = self.get_p_x(density=density, light_weighted=light_weighted)
+        p_t = self.get_p_t(density=density, light_weighted=light_weighted)
+        # since x and t are independent p(t,x)=p(x)p(t)
+        na = np.newaxis
+        p_tx = p_t[:,na,na]*p_x[na,:,:]
+        return p_tx
+
+    def set_p_z_t(self, t_dep=3.):
+        assert (t_dep > 0.1) and (t_dep < 10.0)
+        self.t_dep = t_dep
+        del_t_dep = self.t_dep - self.z_t_interp_grid['t_dep']
+        abs_del_t_dep = np.abs(del_t_dep)
+        idx_t_dep = np.argmin(abs_del_t_dep, axis=-1)
+        self.idx_t_dep = idx_t_dep
+        idx_t_dep = np.ravel(idx_t_dep)
+        z_mu = self.z_t_interp_grid['z'][idx_t_dep]
+        z_mu = np.squeeze(z_mu)
+        self.z_mu = z_mu
+        z_sig2 = self.ahat * z_mu**self.bhat
+        log_z_edg = self.cube.ssps.par_edges[0]
+        del_log_z = log_z_edg[1:] - log_z_edg[:-1]
+        x_xsun = 1. # i.e. assuming galaxy has hydrogen mass fraction = solar
+        lin_z_edg = 10.**log_z_edg * x_xsun
+        nrm = stats.norm(loc=z_mu, scale=z_sig2**0.5)
+        lin_z_edg = lin_z_edg[:, np.newaxis]
+        cdf_z_tx = nrm.cdf(lin_z_edg)
+        p_z_t = cdf_z_tx[1:] - cdf_z_tx[:-1]
+        p_z_t /= np.sum(p_z_t, 0)
+        p_z_t /= del_log_z[:, np.newaxis]
+        self.p_z_t_pars = dict(t_dep=t_dep)
+        self.p_z_t = p_z_t
+
+    def get_p_z_t(self, density=True, light_weighted=False):
+        """Get p(z|t)
+
+        Args:
+            density (bool): whether to return probabilty density (True) or the
+            volume-element weighted probabilty (False)
+            light_weighted (bool): whether to return light-weighted (True) or
+            mass-weighted (False) quantity
+
+        Returns:
+            array
+
+        """
+        if light_weighted is False:
+            p_z_t = self.p_z_t.copy()
+            if density is False:
+                dz = self.cube.ssps.delta_z
+                dz = dz[:, np.newaxis]
+                p_z_t *= dz
+        else:
+            p_tz = self.get_p_tz(density=False, light_weighted=True)
+            p_t = self.get_p_t(density=False, light_weighted=True)
+            p_z_t = p_tz.T/p_t
+            if density:
+                dz = self.cube.ssps.delta_z
+                dz = dz[:, np.newaxis]
+                p_z_t /= dz
+        return p_z_t
+
+
+
+    def get_p_tz(self, density=True, light_weighted=False):
+        """Get p(t,z)
+
+        Args:
+            density (bool): whether to return probabilty density (True) or the
+            volume-element weighted probabilty (False)
+            light_weighted (bool): whether to return light-weighted (True) or
+            mass-weighted (False) quantity
+
+        Returns:
+            array
+
+        """
+        p_z_t = self.get_p_z_t(density=density, light_weighted=False)
+        p_t = self.get_p_t(density=density, light_weighted=False)
+        p_zt = p_z_t*p_t
+        p_tz = p_zt.T
+        if light_weighted:
+            light_weights = self.cube.ssps.light_weights
+            P_tz_mass_wtd = self.get_p_tz(density=False)
+            normalisation = np.sum(P_tz_mass_wtd*light_weights)
+            p_tz = p_tz*light_weights/normalisation
+            if density:
+                dt = self.cube.ssps.delta_t
+                dz = self.cube.ssps.delta_z
+                dtdz = dt[:,np.newaxis] * dz[np.newaxis,:]
+                p_tz /= dtdz
+        return p_tz
+
+    def get_p_z(self, density=True, light_weighted=False):
+        """Get p(z)
+
+        Args:
+            density (bool): whether to return probabilty density (True) or the
+            volume-element weighted probabilty (False)
+            light_weighted (bool): whether to return light-weighted (True) or
+            mass-weighted (False) quantity
+
+        Returns:
+            array
+
+        """
+        p_tz = self.get_p_tz(density=False, light_weighted=light_weighted)
+        p_z = np.sum(p_tz, 0)
+        if density is True:
+            dz = self.cube.ssps.delta_z
+            p_z /= dz
+        return p_z
+
+    def get_p_z_tx(self, density=True, light_weighted=False):
+        """Get p(z|t,x)
+
+        Args:
+            density (bool): whether to return probabilty density (True) or the
+            volume-element weighted probabilty (False)
+            light_weighted (bool): whether to return light-weighted (True) or
+            mass-weighted (False) quantity
+
+        Returns:
+            array
+
+        """
+        p_z_t = self.get_p_z_t(density=density, light_weighted=light_weighted)
+        p_z_tx = p_z_t[:,:,np.newaxis,np.newaxis]
+        cube_shape = (self.cube.nx, self.cube.ny)
+        p_z_tx = np.broadcast_to(p_z_tx, p_z_t.shape+cube_shape)
+        return p_z_tx
+
+    def get_p_txz(self, density=True, light_weighted=False):
+        """Get p(t,x,z)
+
+        Args:
+            density (bool): whether to return probabilty density (True) or the
+            volume-element weighted probabilty (False)
+            light_weighted (bool): whether to return light-weighted (True) or
+            mass-weighted (False) quantity
+
+        Returns:
+            array
+
+        """
+        p_tz = self.get_p_tz(density=density, light_weighted=light_weighted)
+        p_x = self.get_p_x(density=density, light_weighted=light_weighted)
+        na = np.newaxis
+        p_txz = p_tz[:,na,na,:] * p_x[na,:,:,na]
+        return p_txz
+
+    def get_p_tz_x(self, density=True, light_weighted=False):
+        """Get p(t,z|x)
+
+        Args:
+            density (bool): whether to return probabilty density (True) or the
+            volume-element weighted probabilty (False)
+            light_weighted (bool): whether to return light-weighted (True) or
+            mass-weighted (False) quantity
+
+        Returns:
+            array
+
+        """
+        p_tz = self.get_p_tz(density=density, light_weighted=light_weighted)
+        na = np.newaxis
+        cube_shape = (self.cube.nx, self.cube.ny)
+        p_tz_x = np.broadcast_to(p_tz[:,:,na,na], p_tz.shape+cube_shape)
+        return p_tz_x
+
+    def set_p_v_x(self,
+                  mu_v_lims=[-100,100],
+                  sig_v=100.):
+        """Set parameters for p(v|x)
+
+        p(v|x) = N(mu_v(x), sig) where mu_v(x) is linearly interpolated with
+        angle theta, between start/end values specified in `mu_v_lims`
+
+        Args:
+            mu_v_lims: (start, end) values of stream velocity
+            sig_v (float): constant std dev of velocity distribution
+
+        """
+        th = np.arctan2(self.yyp, self.xxp)
+        mu_v = np.zeros_like(th)
+        mu_v_lo, mu_v_hi = mu_v_lims
+        min_th, max_th = np.min(self.theta_lims), np.max(self.theta_lims)
+        idx = np.where(th <= min_th)
+        mu_v[idx] = mu_v_lo
+        idx = np.where(th >= max_th)
+        mu_v[idx] = mu_v_hi
+        idx = np.where((th > min_th) & (th < max_th))
+        mu_v[idx] = (th[idx]-min_th)/(max_th-min_th) * (mu_v_hi-mu_v_lo)
+        mu_v[idx] += mu_v_lo
+        self.p_v_x_pars = dict(mu_v_lims=mu_v_lims, sig_v=sig_v)
+        self.mu_v = mu_v
+        self.sig_v = np.zeros_like(mu_v) + sig_v
+
+    def get_p_v_x(self, v_edg, density=True, light_weighted=False):
+        """Get p(v|x)
+
+        Args:
+            density (bool): whether to return probabilty density (True) or the
+            volume-element weighted probabilty (False)
+            light_weighted (bool): whether to return light-weighted (True) or
+            mass-weighted (False) quantity
+
+        Returns:
+            array
+
+        """
+        norm = stats.norm(loc=self.mu_v, scale=self.sig_v)
+        v = (v_edg[:-1] + v_edg[1:])/2.
+        v = v[:, np.newaxis, np.newaxis]
+        p_v_x = norm.pdf(v)
+        if density is False:
+            dv = v_edg[1:] - v_edg[:-1]
+            dv = dv[:, np.newaxis, np.newaxis]
+            p_v_x *= dv
+        return p_v_x
+
+    def get_p_v(self, v_edg, density=True, light_weighted=False):
+        """Get p(v)
+
+        Args:
+            density (bool): whether to return probabilty density (True) or the
+            volume-element weighted probabilty (False)
+            light_weighted (bool): whether to return light-weighted (True) or
+            mass-weighted (False) quantity
+
+        Returns:
+            array
+
+        """
+        p_v_x = self.get_p_v_x(v_edg, density=density)
+        P_x = self.get_p_x(density=False)
+        p_v = np.sum(p_v_x*P_x, (1,2))
+        return p_v
+
+    def get_p_v_tx(self, v_edg, density=True, light_weighted=False):
+        """Get p(v|t,x)
+
+        Args:
+            density (bool): whether to return probabilty density (True) or the
+            volume-element weighted probabilty (False)
+            light_weighted (bool): whether to return light-weighted (True) or
+            mass-weighted (False) quantity
+
+        Returns:
+            array
+
+        """
+        p_v_x = self.get_p_v_x(v_edg, density=density)
+        nt = self.cube.ssps.par_dims[1]
+        shape = p_v_x.shape
+        shape = (shape[0], nt, shape[1], shape[2])
+        p_v_tx = np.broadcast_to(p_v_x[:,np.newaxis,:,:], shape)
+        return p_v_tx
+
+    def get_p_tvxz(self, v_edg, density=True, light_weighted=False):
+        """Get p(v,t,x,z)
+
+        Args:
+            density (bool): whether to return probabilty density (True) or the
+            volume-element weighted probabilty (False)
+            light_weighted (bool): whether to return light-weighted (True) or
+            mass-weighted (False) quantity
+
+        Returns:
+            array
+
+        """
+        p_tz = self.get_p_tz(density=density, light_weighted=light_weighted)
+        p_v_x = self.get_p_v_x(v_edg, density=density)
+        p_x = self.get_p_x(density=density)
+        na = np.newaxis
+        p_vx = p_v_x * p_x[na,:,:]
+        p_tvxz = p_tz[:,na,na,na,:] * p_vx[na,:,:,:,na]
+        return p_tvxz

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,101 @@
+import pytest
+import matplotlib.pyplot as plt
+import numpy as np
+import popkinmocks as pkm
+
+################################
+# growing disks
+################################
+
+@pytest.fixture(scope="module")
+def my_component():
+    ssps = pkm.model_grids.milesSSPs()
+    ssps.logarithmically_resample(dv=100.)
+    ssps.calculate_fourier_transform()
+    ssps.get_light_weights()
+    cube = pkm.ifu_cube.IFUCube(ssps=ssps, nx=9, ny=10)
+    gc1 = pkm.components.growingDisk(cube=cube, rotation=0., center=(0,0))
+    gc1.set_p_t(lmd=2., phi=0.8)
+    gc1.set_p_x_t(sig_x_lims=(0.5, 0.2),
+                  sig_y_lims=(0.03, 0.1),
+                  alpha_lims=(1.2, 0.8))
+    gc1.set_t_dep(sig_x=0.5,
+                  sig_y=0.1,
+                  alpha=3.,
+                  t_dep_in=0.5,
+                  t_dep_out=5.)
+    gc1.set_p_z_tx()
+    gc1.set_mu_v(sig_x_lims=(0.5, 0.1),
+                 sig_y_lims=(0.1, 0.1),
+                 rmax_lims=(0.5, 1.1),
+                 vmax_lims=(250., 100.),
+                 vinf_lims=(60., 40.))
+    gc1.set_sig_v(sig_x_lims=(0.7, 0.1),
+                  sig_y_lims=(0.2, 0.1),
+                  alpha_lims=(3.0, 2.5),
+                  sig_v_in_lims=(70., 50.),
+                  sig_v_out_lims=(80., 60.))
+    gc1.evaluate_ybar()
+    return ssps, cube, gc1
+
+
+
+@pytest.fixture(scope="module")
+def my_second_component(my_component):
+    ssps, cube, gc1 = my_component
+    gc2 = pkm.components.growingDisk(cube=cube,
+                                     rotation=10.,
+                                     center=(0.05,-0.07))
+    gc2.set_p_t(lmd=1.6, phi=0.3)
+    gc2.set_p_x_t(sig_x_lims=(0.9, 0.5),
+                  sig_y_lims=(0.9, 0.5),
+                  alpha_lims=(1.1, 1.1))
+    gc2.set_t_dep(sig_x=0.9,
+                  sig_y=0.8,
+                  alpha=1.1,
+                  t_dep_in=6.,
+                  t_dep_out=1.)
+    gc2.set_p_z_tx()
+    gc2.set_mu_v(sig_x_lims=(0.5, 0.4),
+                 sig_y_lims=(0.4, 0.6),
+                 rmax_lims=(0.7, 0.2),
+                 vmax_lims=(-150., -190.),
+                 vinf_lims=(-70., -30.))
+    gc2.set_sig_v(sig_x_lims=(0.4, 0.3),
+                  sig_y_lims=(0.3, 0.4),
+                  alpha_lims=(2.0, 1.5),
+                  sig_v_in_lims=(70., 90.),
+                  sig_v_out_lims=(10., 20.))
+    gc2.evaluate_ybar()
+    return gc2
+
+@pytest.fixture(scope="module")
+def my_stream_component():
+    ssps = pkm.model_grids.milesSSPs()
+    ssps.logarithmically_resample(dv=100.)
+    ssps.calculate_fourier_transform()
+    ssps.get_light_weights()
+    cube = pkm.ifu_cube.IFUCube(ssps=ssps, nx=9, ny=10)
+    stream = pkm.components.stream(cube=cube, rotation=0., center=(0.,0))
+    stream.set_p_t(lmd=15., phi=0.3)
+    stream.set_p_x(theta_lims=[-np.pi/2., 2.5*np.pi],
+                   mu_r_lims=[0.2,0.8],
+                   nsmp=1000,
+                   sig=0.1)
+    stream.set_p_z_t(t_dep=5.)
+    stream.set_p_v_x(mu_v_lims=[-100,100], sig_v=110.)
+    stream.evaluate_ybar()
+    return ssps, cube, stream
+
+@pytest.fixture(scope="module")
+def my_three_component_cube(
+    my_component,
+    my_second_component,
+    my_stream_component):
+    """Makes a cube with three components
+    """
+    ssps, cube, gc1 = my_component
+    gc2 = my_second_component
+    ssps, cube, stream = my_stream_component
+    cube.combine_components([gc1, gc2, stream], [0.65, 0.25, 0.1])
+    return cube

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -3,40 +3,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import popkinmocks as pkm
 
-
-@pytest.fixture
-def my_component():
-    ssps = pkm.model_grids.milesSSPs()
-    ssps.logarithmically_resample(dv=100.)
-    ssps.calculate_fourier_transform()
-    ssps.get_light_weights()
-    cube = pkm.ifu_cube.IFUCube(ssps=ssps, nx=9, ny=10)
-    gc1 = pkm.components.growingDisk(cube=cube, rotation=0., center=(0,0))
-    gc1.set_p_t(lmd=2., phi=0.8)
-    gc1.set_p_x_t(sig_x_lims=(0.5, 0.2),
-                  sig_y_lims=(0.03, 0.1),
-                  alpha_lims=(1.2, 0.8))
-    gc1.set_t_dep(sig_x=0.5,
-                  sig_y=0.1,
-                  alpha=3.,
-                  t_dep_in=0.5,
-                  t_dep_out=5.)
-    gc1.set_p_z_tx()
-    gc1.set_mu_v(sig_x_lims=(0.5, 0.1),
-                 sig_y_lims=(0.1, 0.1),
-                 rmax_lims=(0.5, 1.1),
-                 vmax_lims=(250., 100.),
-                 vinf_lims=(60., 40.))
-    gc1.set_sig_v(sig_x_lims=(0.7, 0.1),
-                  sig_y_lims=(0.2, 0.1),
-                  alpha_lims=(3.0, 2.5),
-                  sig_v_in_lims=(70., 50.),
-                  sig_v_out_lims=(80., 60.))
-    gc1.evaluate_ybar()
-    return ssps, cube, gc1
-
-
-
 @pytest.fixture
 def my_kinematic_maps():
     delta_E_v_x = np.array([
@@ -127,7 +93,6 @@ def my_kinematic_maps():
     return delta_E_v_x, delta_var_v_x, delta_skew_v_x, delta_kurt_v_x
 
 
-
 @pytest.fixture
 def my_ybar():
     ybar = np.array([[
@@ -202,38 +167,6 @@ def my_ybar():
         [1.64896074e-07, 2.48648524e-07, 5.13397507e-07, 3.32670755e-07,
          1.98279413e-07]]])
     return ybar
-
-
-@pytest.fixture
-def my_second_component(my_component):
-    ssps, cube, gc1 = my_component
-    gc2 = pkm.components.growingDisk(cube=cube,
-                                     rotation=10.,
-                                     center=(0.05,-0.07))
-    gc2.set_p_t(lmd=1.6, phi=0.3)
-    gc2.set_p_x_t(sig_x_lims=(0.9, 0.5),
-                  sig_y_lims=(0.9, 0.5),
-                  alpha_lims=(1.1, 1.1))
-    gc2.set_t_dep(sig_x=0.9,
-                  sig_y=0.8,
-                  alpha=1.1,
-                  t_dep_in=6.,
-                  t_dep_out=1.)
-    gc2.set_p_z_tx()
-    gc2.set_mu_v(sig_x_lims=(0.5, 0.4),
-                 sig_y_lims=(0.4, 0.6),
-                 rmax_lims=(0.7, 0.2),
-                 vmax_lims=(-150., -190.),
-                 vinf_lims=(-70., -30.))
-    gc2.set_sig_v(sig_x_lims=(0.4, 0.3),
-                  sig_y_lims=(0.3, 0.4),
-                  alpha_lims=(2.0, 1.5),
-                  sig_v_in_lims=(70., 90.),
-                  sig_v_out_lims=(10., 20.))
-    gc2.evaluate_ybar()
-    return gc2
-
-
 
 @pytest.fixture
 def my_two_component_data():

--- a/tests/test_stream_component.py
+++ b/tests/test_stream_component.py
@@ -3,27 +3,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import popkinmocks as pkm
 
-
 @pytest.fixture
-def my_component():
-    ssps = pkm.model_grids.milesSSPs()
-    ssps.logarithmically_resample(dv=100.)
-    ssps.calculate_fourier_transform()
-    ssps.get_light_weights()
-    cube = pkm.ifu_cube.IFUCube(ssps=ssps, nx=9, ny=10)
-    stream = pkm.components.stream(cube=cube, rotation=0., center=(0.,0))
-    stream.set_p_t(lmd=15., phi=0.3)
-    stream.set_p_x(theta_lims=[-np.pi/2., 2.5*np.pi],
-                   mu_r_lims=[0.2,0.8],
-                   nsmp=1000,
-                   sig=0.1)
-    stream.set_p_z_t(t_dep=5.)
-    stream.set_p_v_x(mu_v_lims=[-100,100], sig_v=110.)
-    stream.evaluate_ybar()
-    return ssps, cube, stream
-
-@pytest.fixture
-def my_ybar_trim():
+def my_stream_ybar_trim():
     ybar_trim = np.array([[
         [3.03578561e-19, 1.21683510e-12, 1.48492461e-10, 7.22051417e-12,
          1.69923785e-17],
@@ -101,14 +82,13 @@ def my_ybar_trim():
          4.80982656e-07],
         [2.27580807e-16, 3.64691199e-10, 4.28295437e-08, 2.54728420e-08,
          5.13802296e-11]]])
-
     return ybar_trim
 
-def test_component_normalisation(my_component):
+def test_component_normalisation(my_stream_component):
     """Tests the normalisations of all densities evaluated for a component
 
     """
-    ssps, cube, stream = my_component
+    ssps, cube, stream = my_stream_component
     v_edg = np.linspace(-900, 900, 20)
     dv = v_edg[1] - v_edg[0]
     na = np.newaxis
@@ -248,15 +228,15 @@ def test_component_normalisation(my_component):
     assert np.isclose(np.sum(a*vol_elmt), 1)
 
 def test_component_ybar(
-    my_component,
-    my_ybar_trim,
+    my_stream_component,
+    my_stream_ybar_trim,
     ):
     """Checks value of ybar for one component
 
     """
-    ssps, cube, stream = my_component
+    ssps, cube, stream = my_stream_component
     ybar_trim = stream.ybar[::150, ::2, ::2]
-    assert np.allclose(ybar_trim, my_ybar_trim)
+    assert np.allclose(ybar_trim, my_stream_ybar_trim)
 
 
 

--- a/tests/test_three_cmp_cube.py
+++ b/tests/test_three_cmp_cube.py
@@ -1,0 +1,215 @@
+import pytest
+import matplotlib.pyplot as plt
+import numpy as np
+import popkinmocks as pkm
+
+@pytest.fixture
+def my_ybar():
+    ybar = np.array([
+        [[5.76763530e-07, 6.01458100e-07, 7.02542999e-07, 5.67799694e-07,
+         5.01801101e-07],
+        [8.52188445e-07, 1.22565373e-06, 1.23947863e-06, 1.22571712e-06,
+         8.10549756e-07],
+        [8.94929326e-07, 1.24287066e-06, 1.58971033e-06, 1.38399919e-06,
+         9.93859820e-07]],
+       [[4.44128893e-07, 5.61224756e-07, 7.54600370e-07, 6.39729406e-07,
+         4.99651610e-07],
+        [5.02576737e-07, 8.42308960e-07, 1.24471441e-06, 1.04848845e-06,
+         5.82878480e-07],
+        [4.42256874e-07, 6.70794646e-07, 1.05519622e-06, 7.62919061e-07,
+         5.33204940e-07]],
+       [[6.42590431e-07, 7.69613804e-07, 9.77107772e-07, 8.30953515e-07,
+         6.74716425e-07],
+        [7.98194672e-07, 1.24451237e-06, 1.65110468e-06, 1.43817636e-06,
+         8.57431701e-07],
+        [7.74504667e-07, 1.11876587e-06, 1.51034324e-06, 1.23896257e-06,
+         8.79681573e-07]],
+       [[5.90123150e-07, 7.12761999e-07, 9.20536193e-07, 7.71744084e-07,
+         6.23826138e-07],
+        [7.23524911e-07, 1.14803888e-06, 1.53856385e-06, 1.33618683e-06,
+         7.84514027e-07],
+        [7.02040633e-07, 1.03296432e-06, 1.42257816e-06, 1.13599519e-06,
+         7.98392972e-07]],
+       [[5.59762990e-07, 6.87930118e-07, 9.33738468e-07, 7.72264224e-07,
+         6.02731789e-07],
+        [6.86639267e-07, 1.10758284e-06, 1.53479734e-06, 1.30316166e-06,
+         7.42511867e-07],
+        [6.90575711e-07, 1.04136106e-06, 1.46708159e-06, 1.13326096e-06,
+         7.77261319e-07]],
+       [[5.77502174e-07, 7.05417213e-07, 9.30406743e-07, 7.77774603e-07,
+         6.17843876e-07],
+        [7.02066315e-07, 1.13850200e-06, 1.56050376e-06, 1.35211927e-06,
+         7.67338494e-07],
+        [6.80116001e-07, 1.01798348e-06, 1.44151876e-06, 1.13150253e-06,
+         7.83627180e-07]],
+       [[5.53351592e-07, 6.75834127e-07, 8.99438144e-07, 7.45588500e-07,
+         5.90240608e-07],
+        [6.74327999e-07, 1.10252717e-06, 1.50744599e-06, 1.30920897e-06,
+         7.35825001e-07],
+        [6.53821971e-07, 9.86490254e-07, 1.40697668e-06, 1.09698043e-06,
+         7.56693716e-07]],
+       [[5.17110354e-07, 6.31431446e-07, 8.46956289e-07, 7.01371442e-07,
+         5.50585858e-07],
+        [6.38463579e-07, 1.04324053e-06, 1.42511682e-06, 1.23578022e-06,
+         6.89748284e-07],
+        [6.28313000e-07, 9.44758272e-07, 1.32384470e-06, 1.05452237e-06,
+         7.25887992e-07]],
+       [[4.68086246e-07, 5.76421627e-07, 7.96449602e-07, 6.53129733e-07,
+         5.02306110e-07],
+        [5.80058020e-07, 9.53703388e-07, 1.32450324e-06, 1.13058568e-06,
+         6.23136082e-07],
+        [5.85829801e-07, 8.89405375e-07, 1.24601866e-06, 9.84595238e-07,
+         6.70112532e-07]],
+       [[4.59521171e-07, 5.68027634e-07, 7.78898970e-07, 6.39172465e-07,
+         4.95076786e-07],
+        [5.60320142e-07, 9.33777479e-07, 1.30077580e-06, 1.12024216e-06,
+         6.10770147e-07],
+        [5.51894139e-07, 8.45731370e-07, 1.21530361e-06, 9.42981804e-07,
+         6.41288734e-07]]])
+    return ybar
+
+
+def test_three_component_cube_normalisations(my_three_component_cube):
+    """Checks value of ybar and kurtosis map for a two component mixture model
+
+    """
+    cube = my_three_component_cube
+    ssps = cube.ssps
+    v_edg = np.linspace(-1000, 1000, 50)
+    dv = v_edg[1] - v_edg[0]
+    na = np.newaxis
+    # check p_t
+    a = cube.get_p('t', density=False, light_weighted=False)
+    assert np.isclose(np.sum(a), 1)
+    a = cube.get_p('t', density=True, light_weighted=False)
+    assert np.isclose(np.sum(a*ssps.delta_t), 1)
+    a = cube.get_p('t', density=False, light_weighted=True)
+    assert np.isclose(np.sum(a), 1)
+    a = cube.get_p('t', density=True, light_weighted=True)
+    assert np.isclose(np.sum(a*ssps.delta_t), 1)
+    # check p_x_t
+    a = cube.get_p('x_t', density=False, light_weighted=False, collapse_cmps=True)
+    assert np.allclose(np.sum(a, (0,1)), 1.)
+    a = cube.get_p('x_t', density=True, light_weighted=False, collapse_cmps=True)
+    assert np.allclose(np.sum(a*cube.dx*cube.dy, (0,1)), 1.)
+    a = cube.get_p('x_t', density=False, light_weighted=True, collapse_cmps=True)
+    assert np.allclose(np.sum(a, (0,1)), 1.)
+    a = cube.get_p('x_t', density=True, light_weighted=True, collapse_cmps=True)
+    assert np.allclose(np.sum(a*cube.dx*cube.dy, (0,1)), 1.)
+    # check p_tx
+    a = cube.get_p('tx', density=False, light_weighted=False, collapse_cmps=True)
+    assert np.isclose(np.sum(a), 1.)
+    a = cube.get_p('tx', density=True, light_weighted=False, collapse_cmps=True)
+    assert np.isclose(np.sum(a*ssps.delta_t[:,na,na]*cube.dx*cube.dy), 1)
+    a = cube.get_p('tx', density=False, light_weighted=True, collapse_cmps=True)
+    assert np.isclose(np.sum(a), 1.)
+    a = cube.get_p('tx', density=True, light_weighted=True, collapse_cmps=True)
+    assert np.isclose(np.sum(a*ssps.delta_t[:,na,na]*cube.dx*cube.dy), 1)
+    # check p_z_tx
+    a = cube.get_p('z_tx', density=False, light_weighted=False, collapse_cmps=True)
+    assert np.allclose(np.sum(a, 0), 1.)
+    a = cube.get_p('z_tx', density=True, light_weighted=False, collapse_cmps=True)
+    assert np.allclose(np.sum(a*ssps.delta_z[:,na,na,na], 0), 1.)
+    a = cube.get_p('z_tx', density=False, light_weighted=True, collapse_cmps=True)
+    assert np.allclose(np.sum(a, 0), 1.)
+    a = cube.get_p('z_tx', density=True, light_weighted=True, collapse_cmps=True)
+    assert np.allclose(np.sum(a*ssps.delta_z[:,na,na,na], 0), 1.)
+    # check p_txz
+    a = cube.get_p('txz', density=False, light_weighted=False, collapse_cmps=True)
+    assert np.isclose(np.sum(a), 1)
+    a = cube.get_p('txz', density=True, light_weighted=False, collapse_cmps=True)
+    vol_elmt = ssps.delta_t[:,na,na,na]*cube.dx*cube.dy*ssps.delta_z[na,na,na,:]
+    assert np.isclose(np.sum(a * vol_elmt), 1)
+    a = cube.get_p('txz', density=False, light_weighted=True, collapse_cmps=True)
+    assert np.isclose(np.sum(a), 1)
+    a = cube.get_p('txz', density=True, light_weighted=True, collapse_cmps=True)
+    vol_elmt = ssps.delta_t[:,na,na,na]*cube.dx*cube.dy*ssps.delta_z[na,na,na,:]
+    assert np.isclose(np.sum(a * vol_elmt), 1)
+    # check get_p_x
+    a = cube.get_p('x', density=False, light_weighted=False, collapse_cmps=True)
+    assert np.isclose(np.sum(a), 1)
+    a = cube.get_p('x', density=True, light_weighted=False, collapse_cmps=True)
+    assert np.isclose(np.sum(a*cube.dx*cube.dy), 1)
+    a = cube.get_p('x', density=False, light_weighted=True, collapse_cmps=True)
+    assert np.isclose(np.sum(a), 1)
+    a = cube.get_p('x', density=True, light_weighted=True, collapse_cmps=True)
+    assert np.isclose(np.sum(a*cube.dx*cube.dy), 1)
+    # check get_p_z
+    a = cube.get_p('z', density=False, light_weighted=False, collapse_cmps=True)
+    assert np.isclose(np.sum(a), 1)
+    a = cube.get_p('z', density=True, light_weighted=False, collapse_cmps=True)
+    assert np.isclose(np.sum(a*ssps.delta_z), 1)
+    a = cube.get_p('z', density=False, light_weighted=True, collapse_cmps=True)
+    assert np.isclose(np.sum(a), 1)
+    a = cube.get_p('z', density=True, light_weighted=True, collapse_cmps=True)
+    assert np.isclose(np.sum(a*ssps.delta_z), 1)
+    # check p_tz_x
+    a = cube.get_p('tz_x', density=False, light_weighted=False, collapse_cmps=True)
+    assert np.allclose(np.sum(a, (0,1)), 1.)
+    a = cube.get_p('tz_x', density=True, light_weighted=False, collapse_cmps=True)
+    vol_elmt = ssps.delta_t[:,na,na,na]*ssps.delta_z[na,:,na,na]
+    assert np.allclose(np.sum(a*vol_elmt, (0,1)), 1.)
+    a = cube.get_p('tz_x', density=False, light_weighted=True, collapse_cmps=True)
+    assert np.allclose(np.sum(a, (0,1)), 1.)
+    a = cube.get_p('tz_x', density=True, light_weighted=True, collapse_cmps=True)
+    vol_elmt = ssps.delta_t[:,na,na,na]*ssps.delta_z[na,:,na,na]
+    assert np.allclose(np.sum(a*vol_elmt, (0,1)), 1.)
+    # check p_tz
+    a = cube.get_p('tz', density=False, light_weighted=False, collapse_cmps=True)
+    assert np.isclose(np.sum(a), 1.)
+    a = cube.get_p('tz', density=True, light_weighted=False, collapse_cmps=True)
+    assert np.isclose(np.sum(a*ssps.delta_t[:,na]*ssps.delta_z[na,:]), 1.)
+    a = cube.get_p('tz', density=False, light_weighted=True, collapse_cmps=True)
+    assert np.isclose(np.sum(a), 1.)
+    a = cube.get_p('tz', density=True, light_weighted=True, collapse_cmps=True)
+    assert np.isclose(np.sum(a*ssps.delta_t[:,na]*ssps.delta_z[na,:]), 1.)
+    # check get_p_v_tx
+    a = cube.get_p('v_tx', v_edg=v_edg, density=False, light_weighted=False, collapse_cmps=True)
+    assert np.allclose(np.sum(a, 0), 1.)
+    a = cube.get_p('v_tx', v_edg=v_edg, density=True, light_weighted=False, collapse_cmps=True)
+    assert np.allclose(np.sum(a*dv, 0), 1.)
+    a = cube.get_p('v_tx', v_edg=v_edg, density=False, light_weighted=True, collapse_cmps=True)
+    assert np.allclose(np.sum(a, 0), 1.)
+    a = cube.get_p('v_tx', v_edg=v_edg, density=True, light_weighted=True, collapse_cmps=True)
+    assert np.allclose(np.sum(a*dv, 0), 1.)
+    # check get_p_tvxz
+    a = cube.get_p('tvxz', v_edg=v_edg, density=False, light_weighted=False, collapse_cmps=True)
+    assert np.isclose(np.sum(a), 1)
+    a = cube.get_p('tvxz', v_edg=v_edg, density=True, light_weighted=False, collapse_cmps=True)
+    vol_elmt = ssps.delta_t[:,na,na,na,na]*ssps.delta_z[na,na,na,na,:]
+    vol_elmt *= cube.dx * cube.dy * dv
+    assert np.isclose(np.sum(a*vol_elmt), 1)
+    a = cube.get_p('tvxz', v_edg=v_edg, density=False, light_weighted=True, collapse_cmps=True)
+    assert np.isclose(np.sum(a), 1)
+    a = cube.get_p('tvxz', v_edg=v_edg, density=True, light_weighted=True, collapse_cmps=True)
+    vol_elmt = ssps.delta_t[:,na,na,na,na]*ssps.delta_z[na,na,na,na,:]
+    vol_elmt *= cube.dx * cube.dy * dv
+    assert np.isclose(np.sum(a*vol_elmt), 1)
+    # check get_p_v_x
+    a = cube.get_p('v_x', v_edg=v_edg, density=False, light_weighted=False, collapse_cmps=True)
+    assert np.allclose(np.sum(a, 0), 1.)
+    a = cube.get_p('v_x', v_edg=v_edg, density=True, light_weighted=False, collapse_cmps=True)
+    assert np.allclose(np.sum(a*dv, 0), 1.)
+    a = cube.get_p('v_x', v_edg=v_edg, density=False, light_weighted=True, collapse_cmps=True)
+    assert np.allclose(np.sum(a, 0), 1.)
+    a = cube.get_p('v_x', v_edg=v_edg, density=True, light_weighted=True, collapse_cmps=True)
+    assert np.allclose(np.sum(a*dv, 0), 1.)
+    # check get_p_v
+    a = cube.get_p('v', v_edg=v_edg, density=False, light_weighted=False, collapse_cmps=True)
+    assert np.isclose(np.sum(a), 1.)
+    a = cube.get_p('v', v_edg=v_edg, density=True, light_weighted=False, collapse_cmps=True)
+    assert np.isclose(np.sum(a*dv), 1.)
+    a = cube.get_p('v', v_edg=v_edg, density=False, light_weighted=True, collapse_cmps=True)
+    assert np.isclose(np.sum(a), 1.)
+    a = cube.get_p('v', v_edg=v_edg, density=True, light_weighted=True, collapse_cmps=True)
+    assert np.isclose(np.sum(a*dv), 1.)
+
+
+def test_three_component_cube_ybar(my_three_component_cube, my_ybar):
+    cube = my_three_component_cube
+    ybar = my_ybar
+    print(ybar.shape)
+    assert np.allclose(cube.ybar[::100,::3,::2], ybar)
+
+
+# end


### PR DESCRIPTION
- LW distributions were implemented incorrectly for the cube i.e. for a 
mixture of components
- the LW dist of a mixture is *not* the mixture of individual LW 
distributuons
- instead, LW marginals/conditionals must be calculated from the LW'd 
joint
- also added new tests to check cube density normalisations