### PR TITLE
Simplify conditionals

### DIFF
--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -239,6 +239,17 @@ def test_component_normalisation(my_component):
     assert np.allclose(np.sum(a, (0,1)), 1.)
     a = gc1.get_p_x_t(density=True, light_weighted=True)
     assert np.allclose(np.sum(a*cube.dx*cube.dy, (0,1)), 1.)
+    # check p_txz
+    a = gc1.get_p_txz(density=False, light_weighted=False)
+    assert np.isclose(np.sum(a), 1)
+    a = gc1.get_p_txz(density=True, light_weighted=False)
+    vol_elmt = ssps.delta_t[:,na,na,na]*cube.dx*cube.dy*ssps.delta_z[na,na,na,:]
+    assert np.isclose(np.sum(a * vol_elmt), 1)
+    a = gc1.get_p_txz(density=False, light_weighted=True)
+    assert np.isclose(np.sum(a), 1)
+    a = gc1.get_p_txz(density=True, light_weighted=True)
+    vol_elmt = ssps.delta_t[:,na,na,na]*cube.dx*cube.dy*ssps.delta_z[na,na,na,:]
+    assert np.isclose(np.sum(a * vol_elmt), 1)
     # check p_tx
     a = gc1.get_p_tx(density=False, light_weighted=False)
     assert np.isclose(np.sum(a), 1.)
@@ -257,17 +268,6 @@ def test_component_normalisation(my_component):
     assert np.allclose(np.sum(a, 0), 1.)
     a = gc1.get_p_z_tx(density=True, light_weighted=True)
     assert np.allclose(np.sum(a*ssps.delta_z[:,na,na,na], 0), 1.)
-    # check p_txz
-    a = gc1.get_p_txz(density=False, light_weighted=False)
-    assert np.isclose(np.sum(a), 1)
-    a = gc1.get_p_txz(density=True, light_weighted=False)
-    vol_elmt = ssps.delta_t[:,na,na,na]*cube.dx*cube.dy*ssps.delta_z[na,na,na,:]
-    assert np.isclose(np.sum(a * vol_elmt), 1)
-    a = gc1.get_p_txz(density=False, light_weighted=True)
-    assert np.isclose(np.sum(a), 1)
-    a = gc1.get_p_txz(density=True, light_weighted=True)
-    vol_elmt = ssps.delta_t[:,na,na,na]*cube.dx*cube.dy*ssps.delta_z[na,na,na,:]
-    assert np.isclose(np.sum(a * vol_elmt), 1)
     # check get_p_x
     a = gc1.get_p_x(density=False, light_weighted=False)
     assert np.isclose(np.sum(a), 1)
@@ -286,17 +286,6 @@ def test_component_normalisation(my_component):
     assert np.isclose(np.sum(a), 1)
     a = gc1.get_p_z(density=True, light_weighted=True)
     assert np.isclose(np.sum(a*ssps.delta_z), 1)
-    # check p_tz_x
-    a = gc1.get_p_tz_x(density=False, light_weighted=False)
-    assert np.allclose(np.sum(a, (0,1)), 1.)
-    a = gc1.get_p_tz_x(density=True, light_weighted=False)
-    vol_elmt = ssps.delta_t[:,na,na,na]*ssps.delta_z[na,:,na,na]
-    assert np.allclose(np.sum(a*vol_elmt, (0,1)), 1.)
-    a = gc1.get_p_tz_x(density=False, light_weighted=True)
-    assert np.allclose(np.sum(a, (0,1)), 1.)
-    a = gc1.get_p_tz_x(density=True, light_weighted=True)
-    vol_elmt = ssps.delta_t[:,na,na,na]*ssps.delta_z[na,:,na,na]
-    assert np.allclose(np.sum(a*vol_elmt, (0,1)), 1.)
     # check p_tz
     a = gc1.get_p_tz(density=False, light_weighted=False)
     assert np.isclose(np.sum(a), 1.)
@@ -328,15 +317,6 @@ def test_component_normalisation(my_component):
     vol_elmt = ssps.delta_t[:,na,na,na,na]*ssps.delta_z[na,na,na,na,:]
     vol_elmt *= cube.dx * cube.dy * dv
     assert np.isclose(np.sum(a*vol_elmt), 1)
-    # check get_p_v_x
-    a = gc1.get_p_v_x(v_edg, density=False, light_weighted=False)
-    assert np.allclose(np.sum(a, 0), 1.)
-    a = gc1.get_p_v_x(v_edg, density=True, light_weighted=False)
-    assert np.allclose(np.sum(a*dv, 0), 1.)
-    a = gc1.get_p_v_x(v_edg, density=False, light_weighted=True)
-    assert np.allclose(np.sum(a, 0), 1.)
-    a = gc1.get_p_v_x(v_edg, density=True, light_weighted=True)
-    assert np.allclose(np.sum(a*dv, 0), 1.)
     # check get_p_v
     a = gc1.get_p_v(v_edg, density=False, light_weighted=False)
     assert np.isclose(np.sum(a), 1.)
@@ -346,8 +326,26 @@ def test_component_normalisation(my_component):
     assert np.isclose(np.sum(a), 1.)
     a = gc1.get_p_v(v_edg, density=True, light_weighted=True)
     assert np.isclose(np.sum(a*dv), 1.)
-
-
+    # check p_tz_x
+    a = gc1.get_p('tz_x', density=False, light_weighted=False)
+    assert np.allclose(np.sum(a, (0,1)), 1.)
+    a = gc1.get_p('tz_x', density=True, light_weighted=False)
+    vol_elmt = ssps.delta_t[:,na,na,na]*ssps.delta_z[na,:,na,na]
+    assert np.allclose(np.sum(a*vol_elmt, (0,1)), 1.)
+    a = gc1.get_p('tz_x', density=False, light_weighted=True)
+    assert np.allclose(np.sum(a, (0,1)), 1.)
+    a = gc1.get_p('tz_x', density=True, light_weighted=True)
+    vol_elmt = ssps.delta_t[:,na,na,na]*ssps.delta_z[na,:,na,na]
+    assert np.allclose(np.sum(a*vol_elmt, (0,1)), 1.)
+    # check get_p_v_x
+    a = gc1.get_p('v_x', v_edg=v_edg, density=False, light_weighted=False)
+    assert np.allclose(np.sum(a, 0), 1.)
+    a = gc1.get_p('v_x', v_edg=v_edg, density=True, light_weighted=False)
+    assert np.allclose(np.sum(a*dv, 0), 1.)
+    a = gc1.get_p('v_x', v_edg=v_edg, density=False, light_weighted=True)
+    assert np.allclose(np.sum(a, 0), 1.)
+    a = gc1.get_p('v_x', v_edg=v_edg, density=True, light_weighted=True)
+    assert np.allclose(np.sum(a*dv, 0), 1.)
 
 def test_component_kinematic_maps(
     my_component,

--- a/tests/test_stream_component.py
+++ b/tests/test_stream_component.py
@@ -167,17 +167,6 @@ def test_component_normalisation(my_stream_component):
     assert np.isclose(np.sum(a), 1)
     a = stream.get_p_z(density=True, light_weighted=True)
     assert np.isclose(np.sum(a*ssps.delta_z), 1)
-    # check p_tz_x
-    a = stream.get_p_tz_x(density=False, light_weighted=False)
-    assert np.allclose(np.sum(a, (0,1)), 1.)
-    a = stream.get_p_tz_x(density=True, light_weighted=False)
-    vol_elmt = ssps.delta_t[:,na,na,na]*ssps.delta_z[na,:,na,na]
-    assert np.allclose(np.sum(a*vol_elmt, (0,1)), 1.)
-    a = stream.get_p_tz_x(density=False, light_weighted=True)
-    assert np.allclose(np.sum(a, (0,1)), 1.)
-    a = stream.get_p_tz_x(density=True, light_weighted=True)
-    vol_elmt = ssps.delta_t[:,na,na,na]*ssps.delta_z[na,:,na,na]
-    assert np.allclose(np.sum(a*vol_elmt, (0,1)), 1.)
     # check p_tz
     a = stream.get_p_tz(density=False, light_weighted=False)
     assert np.isclose(np.sum(a), 1.)
@@ -187,24 +176,6 @@ def test_component_normalisation(my_stream_component):
     assert np.isclose(np.sum(a), 1.)
     a = stream.get_p_tz(density=True, light_weighted=True)
     assert np.isclose(np.sum(a*ssps.delta_t[:,na]*ssps.delta_z[na,:]), 1.)
-    # check get_p_v_x
-    a = stream.get_p_v_x(v_edg, density=False, light_weighted=False)
-    assert np.allclose(np.sum(a, 0), 1.)
-    a = stream.get_p_v_x(v_edg, density=True, light_weighted=False)
-    assert np.allclose(np.sum(a*dv, 0), 1.)
-    a = stream.get_p_v_x(v_edg, density=False, light_weighted=True)
-    assert np.allclose(np.sum(a, 0), 1.)
-    a = stream.get_p_v_x(v_edg, density=True, light_weighted=True)
-    assert np.allclose(np.sum(a*dv, 0), 1.)
-    # check get_p_v_tx
-    a = stream.get_p_v_tx(v_edg, density=False, light_weighted=False)
-    assert np.allclose(np.sum(a, 0), 1.)
-    a = stream.get_p_v_tx(v_edg, density=True, light_weighted=False)
-    assert np.allclose(np.sum(a*dv, 0), 1.)
-    a = stream.get_p_v_tx(v_edg, density=False, light_weighted=True)
-    assert np.allclose(np.sum(a, 0), 1.)
-    a = stream.get_p_v_tx(v_edg, density=True, light_weighted=True)
-    assert np.allclose(np.sum(a*dv, 0), 1.)
     # check get_p_v
     a = stream.get_p_v(v_edg, density=False, light_weighted=False)
     assert np.isclose(np.sum(a), 1.)
@@ -227,6 +198,35 @@ def test_component_normalisation(my_stream_component):
     vol_elmt = ssps.delta_t[:,na,na,na,na]*ssps.delta_z[na,na,na,na,:]
     vol_elmt *= cube.dx * cube.dy * dv
     assert np.isclose(np.sum(a*vol_elmt), 1)
+    # check get_p_v_tx
+    a = stream.get_p('v_tx', v_edg=v_edg, density=False, light_weighted=False)
+    assert np.allclose(np.sum(a, 0), 1.)
+    a = stream.get_p('v_tx', v_edg=v_edg, density=True, light_weighted=False)
+    assert np.allclose(np.sum(a*dv, 0), 1.)
+    a = stream.get_p('v_tx', v_edg=v_edg, density=False, light_weighted=True)
+    assert np.allclose(np.sum(a, 0), 1.)
+    a = stream.get_p('v_tx', v_edg=v_edg, density=True, light_weighted=True)
+    assert np.allclose(np.sum(a*dv, 0), 1.)
+    # check p_tz_x
+    a = stream.get_p('tz_x', density=False, light_weighted=False)
+    assert np.allclose(np.sum(a, (0,1)), 1.)
+    a = stream.get_p('tz_x', density=True, light_weighted=False)
+    vol_elmt = ssps.delta_t[:,na,na,na]*ssps.delta_z[na,:,na,na]
+    assert np.allclose(np.sum(a*vol_elmt, (0,1)), 1.)
+    a = stream.get_p('tz_x', density=False, light_weighted=True)
+    assert np.allclose(np.sum(a, (0,1)), 1.)
+    a = stream.get_p('tz_x', density=True, light_weighted=True)
+    vol_elmt = ssps.delta_t[:,na,na,na]*ssps.delta_z[na,:,na,na]
+    assert np.allclose(np.sum(a*vol_elmt, (0,1)), 1.)
+    # check get_p_v_x
+    a = stream.get_p('v_x', v_edg=v_edg, density=False, light_weighted=False)
+    assert np.allclose(np.sum(a, 0), 1.)
+    a = stream.get_p('v_x', v_edg=v_edg, density=True, light_weighted=False)
+    assert np.allclose(np.sum(a*dv, 0), 1.)
+    a = stream.get_p('v_x', v_edg=v_edg, density=False, light_weighted=True)
+    assert np.allclose(np.sum(a, 0), 1.)
+    a = stream.get_p('v_x', v_edg=v_edg, density=True, light_weighted=True)
+    assert np.allclose(np.sum(a*dv, 0), 1.)
 
 def test_component_ybar(
     my_stream_component,


### PR DESCRIPTION
Compute conditionals as joint/marginal

Previously, individual conditional distributions had been individually hard coded. This had two shortcomings, e.g.
1. generalizability. We can now compute any conditional, not just those hard-coded
2. errors! e.g. previously we had coded up $p(v|x) = \int p(v|t,x) p(t) dt$. Though this naively looked right, it did not obey the assumed factorisation $p(t,v,x) = p(t) p(x|t) p(v|t,x)$. The correct expression (which is now used implicitly) is:

$$
p(v|x) = \frac{\int p(t) p(x|t) p(v|t,x) dt}{\int \int p(t) p(x|t) p(v|t,x) dt dv}
$$

Note - this last now correct, but produces different results to the previous version.

Notes:
- done for both individual components, and the whole cube
- required altering tests, removing any that were based on previous implementations of the conditionals